### PR TITLE
Fix for IE7, 8 compatibility on jQuery 1.7.2 & up

### DIFF
--- a/jquery.microdata.js
+++ b/jquery.microdata.js
@@ -214,7 +214,7 @@
   }
 
   // feature detection to use native support where available
-  var t = $('<data itemscope itemtype="type" itemid="id" itemprop="prop" itemref="ref" value="value">')[0];
+  var t = $('<data itemscope itemtype="type" itemid="id" itemprop="prop" itemref="ref" value="value">');
 
   $.fn.extend({
     items: document.getItems && t.itemType && t.itemType.contains ? function(types) {


### PR DESCRIPTION
jQuery 1.7.2 changed the behaviour of the element creation.

In this case, only one element is ever returned on these versions, and no object exists at index 0.

This fix has been tested with your test suite (and in a real application making use of it) against jQuery 1.6.x, 1.7.x and 1.8.x, and fixes both IE 7 and 8.
