### PR TITLE
Create <a> instead of <img> when resolving URL properties

### DIFF
--- a/jquery.microdata.js
+++ b/jquery.microdata.js
@@ -94,22 +94,29 @@
 
   function resolve(elm, attr) {
     // in order to handle <base> and attributes which aren't properly
-    // reflected as URLs, insert a temporary <img> element just before
-    // elm and resolve using its src attribute. the <img> element must
+    // reflected as URLs, insert a temporary <a> element just before
+    // elm and resolve using its href property. the <a> element must
     // be created using the parent document due IE security policy.
     var url = elm.getAttribute(attr);
     if (!url)
       return '';
     var a = ancestor(elm);
     var p = elm.parentNode;
-    var img = (a.createElement ? a : document).createElement('img');
+    var div = (a.createElement ? a : document).createElement('div');
     try {
-      img.setAttribute('src', url);
+      // Setting the href attribute/property on an <a> element
+      // directly doesn't trigger resolution against the base URL in
+      // IE, but creating an <a> element with innerHTML does. We have
+      // to do some acrobatics to avoid having to HTML-escape the URL.
+      // See http://stackoverflow.com/a/22918332/250798
+      div.innerHTML = '<a></a>';
+      div.firstChild.href = url;
+      div.innerHTML = div.innerHTML;
       if (p)
-        p.insertBefore(img, elm);
-      url = img.src;
+        p.insertBefore(div, elm);
+      url = div.firstChild.href;
       if (p)
-        p.removeChild(img);
+        p.removeChild(div);
     } catch (e) {
       // IE>6 throws "TypeError: Access is denied." for mailto:
       // URLs. This is annoying, but harmless to ignore.


### PR DESCRIPTION
The `resolve()` function, which resolves potentially-relative URL properties against the page's base URL, currently creates an `<img>` element with a `src` attribute set to the URL to be resolved. When the element is inserted into the document, the browser tries to fetch an image at that URL. This is at best an annoyance, and potentially harmful.

Instead, we can use an `<a>` element. The caveat, detailed in [this StackOverflow question](http://stackoverflow.com/q/470832/250798), is that setting the `href` property directly doesn't trigger resolution in old versions of IE. There are several good workarounds on that page; I chose [this one](http://stackoverflow.com/a/22918332/250798).

I've tested this change in IE 7-11 and current versions of Firefox, Chrome, and Safari.
